### PR TITLE
[semver]: update jsdoc comments for `inc` according to `ReleaseType`

### DIFF
--- a/types/semver/functions/inc.d.ts
+++ b/types/semver/functions/inc.d.ts
@@ -7,7 +7,7 @@ declare namespace inc {
 }
 
 /**
- * Return the version incremented by the release type (major, minor, patch, or prerelease), or null if it's not valid.
+ * Return the version incremented by the release type (major, premajor, minor, preminor, patch, prepatch, or prerelease), or null if it's not valid.
  */
 declare function inc(
     version: string | SemVer,


### PR DESCRIPTION
**Description:** 
The inc function supports multiple release types

```typescript
export type ReleaseType = 'major' | 'premajor' | 'minor' | 'preminor' | 'patch' | 'prepatch' | 'prerelease';
```

But in the comments, some of the supported types are still missing. It may lead to confusion whether or not this function provides those types, when only comments are read.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/61c7bb49838a155b2b0476bb97d5e707ca80a23b/types/semver/functions/inc.d.ts#L9
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
